### PR TITLE
Unit renaming and big fixes

### DIFF
--- a/Units/energy.hpp
+++ b/Units/energy.hpp
@@ -3,6 +3,8 @@
 #include "unit.hpp"
 
 namespace unit { namespace energy {
-    template <metric_prefix_ratio Prefix>
+    template <metric_prefix_ratio Prefix = no_prefix>
         struct basic_joule : public basic_unit<basic_joule<Prefix>, QuantitativeType::Continuous, Prefix> {};
+
+    using joule = basic_joule;
 }}

--- a/Units/energy.hpp
+++ b/Units/energy.hpp
@@ -3,6 +3,6 @@
 #include "unit.hpp"
 
 namespace unit { namespace energy {
-    template <metric_prefix_ratio P>
-        struct basic_joule : public basic_unit<basic_joule<P>, QuantitativeType::Continuous, P> {};
+    template <metric_prefix_ratio Prefix>
+        struct basic_joule : public basic_unit<basic_joule<Prefix>, QuantitativeType::Continuous, Prefix> {};
 }}

--- a/Units/energy.hpp
+++ b/Units/energy.hpp
@@ -4,5 +4,5 @@
 
 namespace unit { namespace energy {
     template <metric_prefix_ratio P>
-        struct basic_joule : public unit<basic_joule<P>, QuantitativeType::Continuous, P> {};
+        struct basic_joule : public basic_unit<basic_joule<P>, QuantitativeType::Continuous, P> {};
 }}

--- a/Units/unit.hpp
+++ b/Units/unit.hpp
@@ -40,7 +40,7 @@ namespace unit {
 
     template <typename derived, QuantitativeType Q, metric_prefix_ratio R = no_prefix>
         struct basic_unit {
-        using metrix_prefix = R;
+        using metric_prefix = R;
 
         Q value {};
         int base_10_compensator {};

--- a/Units/unit.hpp
+++ b/Units/unit.hpp
@@ -39,7 +39,7 @@ namespace unit {
     struct unit;
 
     template <typename derived, QuantitativeType Q, metric_prefix_ratio R = no_prefix>
-        struct unit {
+        struct basic_unit {
         using metrix_prefix = R;
 
         Q value {};


### PR DESCRIPTION
- add: energy units
- fixed coffee.java package route
- fix namespace change (endl)
- add: money unit with conversions
- renamed namespaces and files
- renamed Energy directory to Units
- add: money numerical operations interface
- removed redundant type defaults
- added money comparison and unmarked functions as friend
- implemented money addition and subtraction, changed cent type
- fixed money addition and subtraction
- added money initializer
- added missing template specializer
- implemented money multiplication by integers
- implemented money multiplication and reformatted
- implemented money division
- implemented money division
- add: inheritable unit with metric prefix
- made power_of_10 checker constexpr
- renamed Real quantative type
- add: joules unit of energy
- add: unit arethmetic interface
- included unit changes in joules
- sync changes
- add: iso standard template inheritance names
- fixed metric_prefix spelling
